### PR TITLE
Don't rewrite url schema for datapackage-url

### DIFF
--- a/app/scripts/directives/user-datasets/template.html
+++ b/app/scripts/directives/user-datasets/template.html
@@ -63,7 +63,7 @@
           </li>
           <li class="edit" ng-if="!!packagerUrl">
             <a data-toggle="tooltip" bootstrap-tooltip data-placement="top" title="Edit"
-               ng-href="{{ packagerUrl + '/provide-data/?package=' + package.url }}" target="_blank"><svg><use xlink:href="#icon-edit" /></svg><span>Edit</span></a>
+               ng-href="{{ packagerUrl + '/provide-data/?package=' + package.url }}"><svg><use xlink:href="#icon-edit" /></svg><span>Edit</span></a>
           </li>
           <li class="delete" ng-if="!!packagerUrl">
             <a data-toggle="popover" confirmation-popover data-on-click="deletePackage(package.id)"
@@ -71,7 +71,7 @@
           </li>
           <li class="view" ng-if="!!viewerUrl && package.loadingStatus.loaded">
             <a data-toggle="tooltip" bootstrap-tooltip data-placement="top" title="View"
-              ng-href="{{ viewerUrl + '/' + package.id }}" target="_blank"><svg><use xlink:href="#icon-open" /></svg><span>View</span></a>
+              ng-href="{{ viewerUrl + '/' + package.id }}"><svg><use xlink:href="#icon-open" /></svg><span>View</span></a>
           </li>
           <li class="download context" ng-init="dropdown.isDownloadVisible = false">
             <a data-toggle="tooltip" bootstrap-tooltip ng-click="dropdown.isDownloadVisible = !dropdown.isDownloadVisible" data-placement="top" title="Download">

--- a/app/scripts/services/os-admin/index.js
+++ b/app/scripts/services/os-admin/index.js
@@ -66,7 +66,6 @@ function getDataPackageMetadata(dataPackage) {
     dataPackage.package.name,
     'datapackage.json'
   ].join('/');
-  originUrl = originUrl.replace(/^http:/, 'https:');
 
   var totalCountOfRecords = (function(dataPackage) {
     var result = 0;

--- a/tests/data/loaded-packages.js
+++ b/tests/data/loaded-packages.js
@@ -10,7 +10,7 @@ module.exports = [
     isPublished: true,
     last_update: 0,
     author: 'Levko Kravets',
-    url: 'https://s3.amazonaws.com/datastore.openspending.org/' +
+    url: 'http://s3.amazonaws.com/datastore.openspending.org/' +
       '583b10ad15f2e7f078afd3431c2c09ea/test/datapackage.json',
     totalCountOfResources: 1,
     totalCountOfRecords: 0,
@@ -28,7 +28,7 @@ module.exports = [
     resources: [
       {
         name: 'boost-moldova-all',
-        url: 'https://s3.amazonaws.com/datastore.openspending.org/' +
+        url: 'http://s3.amazonaws.com/datastore.openspending.org/' +
           '583b10ad15f2e7f078afd3431c2c09ea/test/boost-moldova-all.csv'
       }
     ]
@@ -42,7 +42,7 @@ module.exports = [
     isPublished: true,
     last_update: 0,
     author: 'Levko Kravets',
-    url: 'https://s3.amazonaws.com/datastore.openspending.org/' +
+    url: 'http://s3.amazonaws.com/datastore.openspending.org/' +
       '583b10ad15f2e7f078afd3431c2c09ea/test2/datapackage.json',
     totalCountOfResources: 1,
     totalCountOfRecords: 0,
@@ -60,7 +60,7 @@ module.exports = [
     resources: [
       {
         name: 'test',
-        url: 'https://s3.amazonaws.com/datastore.openspending.org/' +
+        url: 'http://s3.amazonaws.com/datastore.openspending.org/' +
           '583b10ad15f2e7f078afd3431c2c09ea/test2/test.csv'
       }
     ]


### PR DESCRIPTION
Before the datapackage data is displayed by the Admin page, it's datapackage-url property is rewritten to enforce use of https. This causes problems with datastore urls that don't accept https (such as, currently, http://datastore.openspending.org). This PR removes the rewrite. This PR also prevents Edit and View from opening in the windows.